### PR TITLE
Include instructions in quick start to update git[hub,lab] usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,20 @@ workspace-root/
    cd <workspace-directory>
    ```
 
-2. **Prime the workspace:**
+2. **Update configuration for your environment:**
+   ```bash
+   # Edit workspace-config.json to update usernames and projects
+   # Update the "user" section with your GitHub/GitLab usernames:
+   {
+     "user": {
+       "github_username": "your-github-username",
+       "gitlab_username": "your-gitlab-username"
+     }
+   }
+   # Add/remove projects in the "projects" array as needed
+   ```
+
+3. **Prime the workspace:**
    ```bash
    # Using Claude Code
    /prime


### PR DESCRIPTION
I ran the quick-start steps and got all of your forks as my remotes.

I was able to run `/prime` again after updating the `workspace-config.json` and Claude replaced your remotes with my own no problem.

This is a really cool idea and I'll probably be using it moving forward, thanks for sharing :+1: