### PR TITLE
docs: add query command to workspace documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ workspace-root/
 │       └── workspace/             # Workspace management commands  
 │           ├── prime.md           # Project setup command
 │           ├── pull.md            # Workspace update command
-│           └── status.md          # Activity status and task management
+│           ├── status.md          # Activity status and task management
+│           └── query.md           # User query logging and tracking
 ├── tasks/                         # Active task workspaces
 │   ├── 2025-07-23-1430-feature-development-OCM-456/
 │   ├── 2025-07-23-1445-code-review-alice-auth/
@@ -117,6 +118,12 @@ All commands integrate with the activity logging system:
 - Tracks all development activities and metrics
 - Generates reports and summaries
 - **Core system**: Supports all other commands
+
+### 6. Query Logging (`workspace/query.md`)
+- Processes user queries with comprehensive activity logging
+- Tracks query patterns and knowledge gaps
+- Enables learning progression analysis
+- **Always creates**: "user-query" task type
 
 ## Multi-Agent Coordination
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ workspace-root/
 │       └── workspace/             # Workspace management commands
 │           ├── prime.md           # Project setup command
 │           ├── pull.md            # Workspace update command
-│           └── status.md          # Activity status and task management
+│           ├── status.md          # Activity status and task management
+│           └── query.md           # User query logging and tracking
 ├── tasks/                         # Active task workspaces
 │   ├── 2025-07-23-1430-feature-development-OCM-456/
 │   ├── 2025-07-23-1445-code-review-alice-auth/
@@ -90,6 +91,7 @@ claude
 - `/prime` - Set up or refresh all projects
 - `/pull` - Pull latest changes from origin main
 - `/status` - Review workspace activity and manage tasks
+- `/query` - Submit queries with comprehensive activity logging
 - Work on specific projects by navigating to `projects/<project-name>/`
 - All activity is automatically tracked in `workspace-activity.json`
 
@@ -215,6 +217,7 @@ Generate custom reports for specific time periods or projects.
 - `/prime` - Reset and configure all projects
 - `/pull` - Pull latest changes from origin main
 - `/status` - Review workspace activity and manage tasks interactively
+- `/query` - Submit queries with comprehensive logging and tracking
 - Check `workspace-activity.json` for current tasks
 - Review individual project `claude.md` files for specific guidelines
 


### PR DESCRIPTION
- Add query.md to workspace structure in README.md and CLAUDE.md
- Include /query command in common commands list
- Document query logging functionality for user queries
- Maintain consistency across documentation files

🤖 Generated with [Claude Code](https://claude.ai/code)