### PR TITLE
feat: add comprehensive Claude Code agents documentation

### DIFF
--- a/.claude/agents/conversation-note-taker.md
+++ b/.claude/agents/conversation-note-taker.md
@@ -1,0 +1,50 @@
+---
+name: conversation-note-taker
+description: Use this agent when you need to capture and organize key information from the current conversation context into structured notes for future reference. This agent should be used proactively during or after meaningful conversations, discussions, or problem-solving sessions to ensure important insights, decisions, and action items are preserved.
+
+Examples:
+- "That was a really helpful discussion about query performance. Can you summarize the key points?"
+- "We covered a lot of ground on the microservices approach. I want to make sure I don't forget the trade-offs we discussed."
+- "Can you document the architectural decisions we made in this conversation?"
+- "Please create notes from our debugging session for future reference"
+
+This agent specializes in extracting key insights, organizing information hierarchically, and creating actionable summaries with clear next steps.
+color: orange
+---
+
+You are an expert conversation analyst and note-taking specialist. Your primary responsibility is to extract, organize, and document key information from conversation contexts into concise, well-structured notes that users can reference later.
+
+Your core capabilities include:
+- Analyzing conversation flow to identify critical insights, decisions, and action items
+- Distilling complex discussions into clear, actionable summaries
+- Organizing information hierarchically with proper categorization
+- Capturing both explicit statements and implicit conclusions
+- Preserving important context while eliminating redundancy
+
+When processing conversations, you will:
+
+1. **Extract Key Elements**: Identify main topics, decisions made, problems solved, action items, and important insights or recommendations
+
+2. **Structure Information**: Organize notes using clear headings, bullet points, and logical flow that makes information easy to scan and reference
+
+3. **Maintain Context**: Include enough background information so notes are meaningful when reviewed later, but avoid unnecessary verbosity
+
+4. **Highlight Actionables**: Clearly distinguish between informational content and items requiring follow-up or implementation
+
+5. **Use Consistent Format**: Follow a standardized note structure that includes:
+   - Date and context summary
+   - Key topics discussed
+   - Important decisions or conclusions
+   - Action items or next steps
+   - Relevant technical details or references
+
+6. **Save Appropriately**: Create notes in the designated notes directory with descriptive filenames that include date and topic for easy retrieval
+
+Your notes should be:
+- Concise yet comprehensive
+- Scannable with clear visual hierarchy
+- Actionable with specific next steps when applicable
+- Self-contained with sufficient context
+- Properly categorized and tagged for future reference
+
+Always aim to create notes that will be valuable to the user days, weeks, or months later, ensuring they can quickly understand what was discussed and what actions need to be taken.

--- a/.claude/agents/docs-sync-specialist.md
+++ b/.claude/agents/docs-sync-specialist.md
@@ -1,6 +1,14 @@
 ---
 name: docs-sync-specialist
-description: Use this agent when you need to ensure documentation stays synchronized with recent code changes, after implementing new features, modifying APIs, updating configuration files, or when preparing for releases. Examples: <example>Context: User has just implemented a new authentication system with JWT tokens. user: 'I just finished implementing JWT authentication in the auth service' assistant: 'Great work on the JWT implementation! Let me use the docs-sync-specialist agent to review the recent changes and update any relevant documentation.' <commentary>Since new authentication functionality was added, use the docs-sync-specialist to ensure API docs, setup guides, and security documentation reflect the JWT implementation.</commentary></example> <example>Context: User has modified database schema and wants to ensure docs are current. user: 'I updated the user table schema to include new fields for profile data' assistant: 'I'll use the docs-sync-specialist agent to review the schema changes and update the database documentation accordingly.' <commentary>Database schema changes require documentation updates for API references, migration guides, and data model documentation.</commentary></example>
+description: Use this agent when you need to ensure documentation stays synchronized with recent code changes, after implementing new features, modifying APIs, updating configuration files, or when preparing for releases. The agent analyzes recent commits and updates relevant documentation files to maintain accuracy and consistency.
+
+Examples:
+- "I just finished implementing JWT authentication in the auth service"
+- "I updated the user table schema to include new fields for profile data"  
+- "Can you review the recent API changes and update the documentation?"
+- "We need to prepare documentation for the upcoming release"
+
+This agent specializes in identifying documentation gaps, updating existing docs rather than creating new ones, and ensuring examples reflect current implementation.
 color: cyan
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 workspace-activity.json
 /tasks
 /reports
+/notes
 
 # IDE files
 .idea/

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,9 @@ This documentation directory provides comprehensive guides for setting up and us
 
 ## Documentation Structure
 
+### Core Guides
+- **[Claude Code Agents](/home/croche/Work/projects/docs/claude-code-agents.md)** - Complete guide to using specialized Claude Code agents for focused tasks
+
 ### Setup Guides
 - **[Prerequisites](/home/croche/Work/projects/docs/setup/prerequisites.md)** - All CLI tools required by workspace commands
 - **[GitHub CLI Setup](/home/croche/Work/projects/docs/setup/github-cli-setup.md)** - GitHub CLI installation, authentication, and configuration
@@ -38,6 +41,24 @@ The following workspace commands require GitHub CLI (`gh`):
 ### JIRA CLI Commands
 The following workspace commands require JIRA CLI (`jira`):
 - **JIRA Implementation** (`development/implement-jira.md`) - Fetches JIRA issues and implements requirements
+
+## Available Claude Code Agents
+
+The workspace includes specialized agents for focused tasks:
+
+### Documentation Agents
+- **docs-sync-specialist** - Ensures documentation stays synchronized with recent code changes
+  - Use after implementing new features or APIs
+  - Automatically identifies and updates outdated documentation
+  - Maintains consistency across all documentation files
+
+### Productivity Agents  
+- **conversation-note-taker** - Captures and organizes key information from conversations
+  - Creates structured notes from technical discussions
+  - Documents architectural decisions and trade-offs
+  - Preserves important insights for future reference
+
+**Learn more**: See the complete [Claude Code Agents Guide](/home/croche/Work/projects/docs/claude-code-agents.md) for detailed usage instructions and best practices.
 
 ## Support
 

--- a/docs/claude-code-agents.md
+++ b/docs/claude-code-agents.md
@@ -1,0 +1,231 @@
+# Claude Code Agents Guide
+
+This guide explains how to use the specialized Claude Code agents available in your workspace. These agents are designed to handle specific types of tasks with focused expertise and dedicated system prompts.
+
+## What are Claude Code Agents?
+
+Claude Code agents are specialized AI assistants that operate with specific expertise and focused responsibilities. Each agent:
+
+- **Operates independently** with its own context window separate from the main conversation
+- **Has specialized knowledge** for specific types of tasks (documentation, note-taking, code review, etc.)
+- **Uses focused system prompts** that define their role and capabilities
+- **Can access specific tools** relevant to their specialization
+- **Integrates seamlessly** with your existing Claude Code workflow
+
+## Available Agents
+
+### 1. Documentation Sync Specialist (`docs-sync-specialist`)
+
+**Purpose**: Ensures documentation stays synchronized with recent code changes
+
+**When to use**:
+- After implementing new features or APIs
+- When modifying configuration files or system architecture
+- Before releases to ensure docs are current
+- When you notice documentation gaps or outdated information
+
+**Examples**:
+```
+"I just finished implementing JWT authentication in the auth service"
+"I updated the user table schema to include new fields for profile data"
+"Can you review the recent API changes and update the documentation?"
+```
+
+**What it does**:
+- Analyzes recent commits and code changes (last 7-14 days)
+- Identifies documentation that needs updates
+- Updates existing docs rather than creating new ones
+- Ensures examples and code snippets reflect current implementation
+- Maintains consistency in terminology and formatting
+- Updates version numbers and changelog entries
+
+### 2. Conversation Note Taker (`conversation-note-taker`)
+
+**Purpose**: Captures and organizes key information from conversations into structured notes
+
+**When to use**:
+- After meaningful technical discussions
+- Following architectural decision sessions
+- When you want to preserve problem-solving insights
+- To document decisions and trade-offs for future reference
+
+**Examples**:
+```
+"That was a helpful discussion about database optimization. Can you summarize the key points?"
+"We covered a lot of ground on the microservices approach. I want to preserve the trade-offs we discussed."
+"Can you document the architectural decisions we made?"
+```
+
+**What it does**:
+- Extracts key insights, decisions, and action items from conversations
+- Creates structured notes with clear hierarchy and organization
+- Highlights actionable items that require follow-up
+- Includes sufficient context for future reference
+- Saves notes with descriptive filenames including date and topic
+
+## How to Use Agents
+
+### Automatic Delegation
+
+Claude Code can automatically delegate tasks to the appropriate agent based on:
+- Your task description
+- The agent's specialized description
+- Available context and tools
+
+Simply describe what you need, and Claude Code will invoke the appropriate agent:
+
+```
+"I need to update documentation after adding the new payment API"
+→ Automatically uses docs-sync-specialist
+
+"Can you summarize our discussion about the database schema changes?"
+→ Automatically uses conversation-note-taker
+```
+
+### Explicit Invocation
+
+You can explicitly request a specific agent:
+
+```
+"Use the docs-sync-specialist to review recent changes"
+"Have the conversation-note-taker document this discussion"
+```
+
+## Agent File Structure
+
+Agents are defined using Markdown files with YAML frontmatter located in `.claude/agents/`:
+
+```markdown
+---
+name: agent-name
+description: When this agent should be invoked
+color: visual-identifier-color
+---
+
+System prompt defining the agent's role and capabilities
+```
+
+### Key Configuration Fields
+
+- **`name`**: Unique identifier (lowercase, hyphen-separated)
+- **`description`**: Detailed explanation of when to use this agent
+- **`color`**: Visual identifier for the agent in Claude Code interface
+- **System prompt**: Detailed instructions defining the agent's expertise and behavior
+
+## Best Practices
+
+### When to Use Agents
+
+✅ **Use agents when**:
+- You have a specific, focused task that matches an agent's expertise
+- You need specialized knowledge or approach for the task
+- The task benefits from dedicated context and tools
+- You want to preserve main conversation context for other work
+
+❌ **Don't use agents when**:
+- The task is simple and general
+- You need broad, multi-domain assistance
+- The overhead of agent delegation isn't justified
+- You're in an exploratory conversation phase
+
+### Choosing the Right Agent
+
+1. **docs-sync-specialist**: For any documentation-related work, especially after code changes
+2. **conversation-note-taker**: For capturing and organizing discussion outcomes
+3. **Main Claude Code**: For general development, exploratory work, and multi-domain tasks
+
+### Working with Agent Output
+
+- **Review agent recommendations**: Agents provide specialized insights, but you decide what to implement
+- **Maintain context**: Important decisions made by agents are preserved in your main conversation
+- **Follow up appropriately**: Agent work may require additional actions in your main workflow
+
+## Integration with Workspace Workflow
+
+Agents integrate seamlessly with your existing workspace system:
+
+### Activity Logging
+- Agent work is logged in `workspace-activity.json`
+- Task tracking includes agent involvement
+- Reports include agent contributions
+
+### Project Context
+- Agents access project-specific configuration from `claude.md` files
+- Project coding standards and conventions are respected
+- Integration with existing documentation structure
+
+### Multi-Agent Coordination
+- Multiple agents can work together on complex tasks
+- Clean handoffs between agents and main Claude Code
+- Conflict prevention and resolution
+
+## Creating Custom Agents
+
+To create a new agent for your specific needs:
+
+1. **Identify the specialization**: What specific expertise or task type needs a dedicated agent?
+
+2. **Create the agent file** in `.claude/agents/your-agent-name.md`:
+   ```markdown
+   ---
+   name: your-agent-name
+   description: Detailed description of when to use this agent
+   color: blue
+   ---
+   
+   Your specialized system prompt defining the agent's role and capabilities
+   ```
+
+3. **Follow best practices**:
+   - Create focused agents with single responsibilities
+   - Write detailed, specific system prompts
+   - Include clear usage examples in the description
+   - Test the agent with representative tasks
+
+4. **Document the agent**: Update this guide to include your new agent
+
+## Troubleshooting
+
+### Common Issues
+
+**Agent not being invoked automatically**:
+- Check that your task description matches the agent's description
+- Try explicit invocation using the agent name
+- Verify the agent file syntax is correct
+
+**Agent producing unexpected results**:
+- Review the agent's system prompt for clarity
+- Check if the task truly matches the agent's specialization
+- Consider if the main Claude Code would be more appropriate
+
+**Context issues**:
+- Agents operate with separate context windows
+- Important information may need to be restated for the agent
+- Consider summarizing relevant context when invoking agents
+
+### Getting Help
+
+1. **Check agent descriptions**: Review `.claude/agents/` files for detailed usage guidance
+2. **Test with simple tasks**: Start with straightforward tasks to understand agent behavior
+3. **Use explicit invocation**: If automatic delegation isn't working, try explicit agent requests
+4. **Fall back to main Claude Code**: For complex or multi-domain tasks, use the main assistant
+
+## Summary
+
+Claude Code agents provide specialized expertise for specific task types, helping you:
+
+- **Maintain documentation** that stays current with code changes
+- **Capture important insights** from technical discussions
+- **Work more efficiently** with focused, expert assistance
+- **Preserve context** for complex, multi-step workflows
+
+Choose agents based on your specific needs, and don't hesitate to use the main Claude Code for general development and exploration work.
+
+---
+
+**Related Documentation**:
+- [Claude Code Workspace Documentation](/home/croche/Work/projects/docs/README.md)
+- [Workspace Integration Guide](/home/croche/Work/projects/docs/integration/workspace-integration.md)
+- [CLAUDE.md Workspace Configuration](/home/croche/Work/projects/CLAUDE.md)
+
+**Agent Files Location**: `/home/croche/Work/projects/.claude/agents/`


### PR DESCRIPTION
- Add complete user guide for .claude/agents directory usage
- Document docs-sync-specialist and conversation-note-taker agents
- Include usage patterns, best practices, and troubleshooting
- Update main documentation with agents section
- Enhance agent descriptions for better automatic delegation
- Follow Anthropic's official sub-agents recommendations

🤖 Generated with [Claude Code](https://claude.ai/code)